### PR TITLE
Tidied up US 01.01.01

### DIFF
--- a/code/app/src/main/java/com/example/ctrlaltelite/AddFragment.java
+++ b/code/app/src/main/java/com/example/ctrlaltelite/AddFragment.java
@@ -211,13 +211,9 @@ public class AddFragment extends Fragment {
             Toast.makeText(getContext(), "Emotional state cannot be the default option", Toast.LENGTH_SHORT).show();
             return;
         }
-        if (editSocialSituation.getSelectedItemPosition() == 0) {
-            Toast.makeText(getContext(), "Social situation cannot be the default option", Toast.LENGTH_SHORT).show();
-            return;
-        }
 
         String selectedEmotion = dropdownMood.getSelectedItem().toString();
-        String socialSituation = editSocialSituation.getSelectedItem().toString();
+        String socialSituation = editSocialSituation.getSelectedItemPosition() == 0 ? null : editSocialSituation.getSelectedItem().toString();
         String trigger = editTrigger.getText().toString();
         String timeStamp = String.valueOf(new Date());
         GeoPoint location = switchLocation.isChecked() ? getUserLocation() : null;
@@ -239,6 +235,12 @@ public class AddFragment extends Fragment {
             return;
         }
         */
+
+        // Ensure either text reason or image is provided
+        if (reason.isEmpty() && imageRef == null) {
+            Toast.makeText(getContext(), "Either a reason or an image must be provided", Toast.LENGTH_SHORT).show();
+            return;
+        }
 
         // Adding the conditions for the textual reason
         if (reason.length() > 20) {


### PR DESCRIPTION
updated saveMoodEvent to enforce that either a reason (text) or an image must be provided. Also,the social situation is now optional, and if left unselected, it will be stored as null in Firestore.